### PR TITLE
Multiple remote repos

### DIFF
--- a/packdeps.cabal
+++ b/packdeps.cabal
@@ -25,6 +25,7 @@ library
                    , time                      >= 1.1.4    && < 1.3
                    , containers                >= 0.2      && < 0.5
                    , directory                 >= 1.0      && < 1.2
+                   , filepath                  >= 1.1      && < 1.3
     exposed-modules: Distribution.PackDeps
     ghc-options:     -Wall
 


### PR DESCRIPTION
I've added (quick and dirty) support for reading package versions for multiple remote repos. This is useful if you have a separate, private hackage running.
