### PR TITLE
improvements to getReverseR package output

### DIFF
--- a/packdeps-yesod.hs
+++ b/packdeps-yesod.hs
@@ -297,17 +297,19 @@ getReverseR dep = do
         setTitle [shamlet|Reverse dependencies for #{dep}|]
         addCassius mainCassius
         addHamlet [hamlet|
-<h1>Reverse dependencies for #{dep} #{display version}
+<h1>#{show $ length rels} reverse dependencies for #{dep}-#{display version}
 <table>
     <tr>
         <th>Package
         <th>Uses current version?
     $forall rel <- rels
         <tr>
-            <td
-                <a href=@{ReverseR $ pack $ fst rel}>#{fst rel}
-            $if withinRange version (snd rel)
-                <td>Yes
+            $if Map.member (fst rel) reverse
+                <td><a href=@{ReverseR $ pack $ fst rel}>#{fst rel}
             $else
-                <td style="color:#900">No (#{display (snd rel)})
+                <td>#{fst rel}
+            $if withinRange version (snd rel)
+                <td>#{display (snd rel)}
+            $else
+                <td style="background-color:#fbb">#{display (snd rel)}
 |]


### PR DESCRIPTION
This should fix the 404 issue you mentioned in my previous pull request
and also makes some other improvements I think to the output.
- display total number of reverse deps in heading
- only link to packages that have reverse deps, to avoid 404's
- always display package version ranges, since it's useful information
- highlight packages that require an older package version
  with a light red background instead of Yes/No

It works for me with yesod-0.8 but I haven't tested yet on 0.9.
