### PR TITLE
Extend dependency constraints to allow building with GHC 7.4.1 RC1

### DIFF
--- a/packdeps.cabal
+++ b/packdeps.cabal
@@ -25,11 +25,11 @@ library
                    , split                     >= 0.1.2.3  && < 0.2
                    , bytestring                >= 0.9      && < 0.10
                    , text                      >= 0.7      && < 0.12
-                   , Cabal                     >= 1.8      && < 1.13
+                   , Cabal                     >= 1.8      && < 1.15
                    , time                      >= 1.1.4
                    , containers                >= 0.2      && < 0.5
                    , directory                 >= 1.0      && < 1.2
-                   , filepath                  >= 1.1      && < 1.3
+                   , filepath                  >= 1.1      && < 1.4
     exposed-modules: Distribution.PackDeps
     ghc-options:     -Wall
 


### PR DESCRIPTION
Note: I have only tested the CLI-tool building -- I couldn't build the yesod version as the yesod libraries don't build w/ GHC 7.4 yet...
