### PR TITLE
avoid circular reverse self-dependencies

### DIFF
--- a/Distribution/PackDeps.hs
+++ b/Distribution/PackDeps.hs
@@ -148,7 +148,10 @@ getReverses (Newest newest) =
 
     combine = unionsWith HMap.union
 
-    toTuple rel (dep, PUVersionRange _ range) = HMap.singleton dep $ HMap.singleton rel range
+    toTuple rel (dep, PUVersionRange _ range) =
+        if rel == dep
+            then HMap.empty
+            else HMap.singleton dep $ HMap.singleton rel range
 
     hoisted :: HMap.HashMap PackageName (HMap.HashMap PackageName (VersionRange Version))
     hoisted = combine $ map toTuples $ HMap.toList newest


### PR DESCRIPTION
Packdeps' reverse dependencies output currently lists self-dependencies.  Eg:

http://packdeps.haskellers.com/reverse/Agda
http://packdeps.haskellers.com/reverse/pandoc

This patch fixes the reverse output so that self-dependencies are no longer listed.  I tested it locally and it seems to fix the problem for me.
