### PR TITLE
add test suites and benchmarks sections to command line checker

### DIFF
--- a/Distribution/PackDeps.hs
+++ b/Distribution/PackDeps.hs
@@ -180,7 +180,9 @@ getDescInfo gpd = DescInfo
 getDeps :: GenericPackageDescription -> [Dependency]
 getDeps x = concat
           $ maybe id ((:) . condTreeConstraints) (condLibrary x)
-          $ map (condTreeConstraints . snd) (condExecutables x)
+          $ (map (condTreeConstraints . snd) (condExecutables x)
+             ++ map (condTreeConstraints . snd) (condTestSuites x)
+             ++ map (condTreeConstraints . snd) (condBenchmarks x))
 
 checkDeps :: Newest -> DescInfo
           -> (PackageName, Version, CheckDepsRes)


### PR DESCRIPTION
I like using the command line checker. It didn't check the test suite and benchmark section dependencies, so I added them.