### PR TITLE
Cli improvements

### DIFF
--- a/Distribution/PackDeps.hs
+++ b/Distribution/PackDeps.hs
@@ -9,6 +9,7 @@ module Distribution.PackDeps
     , parseNewest
       -- * Check a package
     , checkDeps
+    , checkLibDeps
       -- * Get a single package
     , getPackage
     , parsePackage
@@ -192,8 +193,16 @@ getLibDeps gpd = maybe [] condTreeConstraints (condLibrary gpd)
 
 checkDeps :: Newest -> DescInfo
           -> (PackageName, Version, CheckDepsRes)
-checkDeps newest desc =
-    case mapMaybe (notNewest newest) $ diDeps desc of
+checkDeps = checkDepsImpl diDeps
+
+checkLibDeps :: Newest -> DescInfo
+             -> (PackageName, Version, CheckDepsRes)
+checkLibDeps = checkDepsImpl diLibDeps
+
+checkDepsImpl :: (DescInfo -> [Dependency]) -> Newest -> DescInfo
+              -> (PackageName, Version, CheckDepsRes)
+checkDepsImpl deps newest desc =
+    case mapMaybe (notNewest newest) $ deps desc of
         [] -> (name, version, AllNewest)
         x -> let y = map head $ group $ sort $ map fst x
                  et = maximum $ map snd x

--- a/Distribution/PackDeps.hs
+++ b/Distribution/PackDeps.hs
@@ -16,6 +16,7 @@ module Distribution.PackDeps
       -- * Get multiple packages
     , filterPackages
     , deepDeps
+    , deepLibDeps
       -- * Reverse dependencies
     , Reverses
     , getReverses
@@ -161,6 +162,7 @@ getReverses newest =
 data DescInfo = DescInfo
     { diHaystack :: String
     , diDeps :: [Dependency]
+    , diLibDeps :: [Dependency]
     , diPackage :: PackageIdentifier
     , diSynopsis :: String
     }
@@ -170,6 +172,7 @@ getDescInfo :: GenericPackageDescription -> DescInfo
 getDescInfo gpd = DescInfo
     { diHaystack = map toLower $ author p ++ maintainer p ++ name
     , diDeps = getDeps gpd
+    , diLibDeps = getLibDeps gpd
     , diPackage = pi'
     , diSynopsis = synopsis p
     }
@@ -178,11 +181,14 @@ getDescInfo gpd = DescInfo
     pi'@(PackageIdentifier (PackageName name) _) = package p
 
 getDeps :: GenericPackageDescription -> [Dependency]
-getDeps x = concat
-          $ maybe id ((:) . condTreeConstraints) (condLibrary x)
-          $ (map (condTreeConstraints . snd) (condExecutables x)
-             ++ map (condTreeConstraints . snd) (condTestSuites x)
-             ++ map (condTreeConstraints . snd) (condBenchmarks x))
+getDeps x = getLibDeps x ++ concat
+    [ concatMap (condTreeConstraints . snd) (condExecutables x)
+    , concatMap (condTreeConstraints . snd) (condTestSuites x)
+    , concatMap (condTreeConstraints . snd) (condBenchmarks x)
+    ]
+
+getLibDeps :: GenericPackageDescription -> [Dependency]
+getLibDeps gpd = maybe [] condTreeConstraints (condLibrary gpd)
 
 checkDeps :: Newest -> DescInfo
           -> (PackageName, Version, CheckDepsRes)
@@ -247,7 +253,14 @@ filterPackages needle =
 
 -- | Find all packages depended upon by the given list of packages.
 deepDeps :: Newest -> [DescInfo] -> [DescInfo]
-deepDeps newest dis0 =
+deepDeps = deepDepsImpl diDeps
+
+-- | Find all packages depended upon by the given list of packages.
+deepLibDeps :: Newest -> [DescInfo] -> [DescInfo]
+deepLibDeps = deepDepsImpl diLibDeps
+
+deepDepsImpl :: (DescInfo -> [Dependency]) -> Newest -> [DescInfo] -> [DescInfo]
+deepDepsImpl deps newest dis0 =
     go Set.empty dis0
   where
     go _ [] = []
@@ -257,7 +270,7 @@ deepDeps newest dis0 =
       where
         PackageIdentifier (PackageName name) _ = diPackage di
         viewed' = Set.insert name viewed
-        newDis = mapMaybe getDI $ diDeps di
+        newDis = mapMaybe getDI $ deps di
         getDI :: Dependency -> Maybe DescInfo
         getDI (Dependency (PackageName name') _) = do
             pi' <- Map.lookup name' newest

--- a/tools/packdeps-cli.hs
+++ b/tools/packdeps-cli.hs
@@ -4,6 +4,7 @@ import System.Environment (getArgs, getProgName)
 import System.Exit (exitFailure, exitSuccess)
 import Distribution.Text (display)
 import Distribution.Package (PackageName (PackageName))
+import Control.Monad (liftM)
 
 main :: IO ()
 main = do
@@ -13,40 +14,49 @@ main = do
         ["help"] -> usageExit
         _ | "-h" `elem` args || "--help" `elem` args -> usageExit
         _ -> do
-            isGood <- run args
+            isGood <- run ("--recursive" `elem` args) (filter (/= "--recursive") args)
             if isGood then exitSuccess else exitFailure
 
-run :: [String] -> IO Bool
-run args = do
+checkDepsCli :: Newest -> DescInfo -> IO Bool
+checkDepsCli newest di =
+    case checkDeps newest di of
+        (pn, v, AllNewest) -> do
+            putStrLn $ concat
+                [ unPackageName pn
+                , "-"
+                , display v
+                , ": Can use newest versions of all dependencies"
+                ]
+            return True
+        (pn, v, WontAccept p _) -> do
+            putStrLn $ concat
+                [ unPackageName pn
+                , "-"
+                , display v
+                , ": Cannot accept the following packages"
+                ]
+            forM_ p $ \(x, y) -> putStrLn $ x ++ " " ++ y
+            return False
+
+run :: Bool        -- ^ Check transitive dependencies
+    -> [FilePath]  -- ^ .cabal filenames
+    -> IO Bool
+run deep args = do
     newest <- loadNewest
     foldM (go newest) True args
   where
     go newest wasAllGood fp = do
         mdi <- loadPackage fp
-        di <-
-            case mdi of
-                Just di -> return di
-                Nothing -> error $ "Could not parse cabal file: " ++ fp
-        allGood <- case checkDeps newest di of
-            (pn, v, AllNewest) -> do
-                putStrLn $ concat
-                    [ unPackageName pn
-                    , "-"
-                    , display v
-                    , ": Can use newest versions of all dependencies"
-                    ]
-                return True
-            (pn, v, WontAccept p _) -> do
-                putStrLn $ concat
-                    [ unPackageName pn
-                    , "-"
-                    , display v
-                    , ": Cannot accept the following packages"
-                    ]
-                forM_ p $ \(x, y) -> putStrLn $ x ++ " " ++ y
-                return False
+        di <- case mdi of
+             Just di -> return di
+             Nothing -> error $ "Could not parse cabal file: " ++ fp
+        allGood <- checkDepsCli newest di
+        depsGood <- if deep
+                       then do putStrLn $ "\nTransitive dependencies:"
+                               allM (checkDepsCli newest) (deepDeps newest [di])
+                       else return True
         putStrLn ""
-        return $ wasAllGood && allGood
+        return $ wasAllGood && allGood && depsGood
 
 unPackageName :: PackageName -> String
 unPackageName (PackageName n) = n
@@ -56,8 +66,13 @@ usageExit :: IO a
 usageExit = do
     pname <- getProgName
     putStrLn $ "\n"
-        ++ "Usage: " ++ pname ++ " pkgname.cabal pkgname2.cabal...\n\n"
+        ++ "Usage: " ++ pname ++ " [--recursive] pkgname.cabal pkgname2.cabal...\n\n"
         ++ "Check the given cabal file's dependency list to make sure that it does not exclude\n"
         ++ "the newest package available. Its probably worth running the 'cabal update' command\n"
         ++ "immediately before running this program.\n"
     exitSuccess
+
+-- | Non short-circuiting monadic version of 'all'
+-- Duh, pre-AMP code.
+allM :: Monad m => (a -> m Bool) -> [a] -> m Bool
+allM f xs = and `liftM` mapM f xs

--- a/tools/packdeps-cli.hs
+++ b/tools/packdeps-cli.hs
@@ -56,7 +56,7 @@ usageExit :: IO a
 usageExit = do
     pname <- getProgName
     putStrLn $ "\n"
-        ++ "Usage: " ++ pname ++ " pkgname.cabal\n\n"
+        ++ "Usage: " ++ pname ++ " pkgname.cabal pkgname2.cabal...\n\n"
         ++ "Check the given cabal file's dependency list to make sure that it does not exclude\n"
         ++ "the newest package available. Its probably worth running the 'cabal update' command\n"
         ++ "immediately before running this program.\n"

--- a/tools/packdeps-cli.hs
+++ b/tools/packdeps-cli.hs
@@ -53,7 +53,7 @@ run deep args = do
         allGood <- checkDepsCli newest di
         depsGood <- if deep
                        then do putStrLn $ "\nTransitive dependencies:"
-                               allM (checkDepsCli newest) (deepDeps newest [di])
+                               allM (checkDepsCli newest) (deepLibDeps newest [di])
                        else return True
         putStrLn ""
         return $ wasAllGood && allGood && depsGood

--- a/tools/packdeps-cli.hs
+++ b/tools/packdeps-cli.hs
@@ -11,6 +11,7 @@ main = do
     case args of
         [] -> usageExit
         ["help"] -> usageExit
+        _ | "-h" `elem` args || "--help" `elem` args -> usageExit
         _ -> do
             isGood <- run args
             if isGood then exitSuccess else exitFailure


### PR DESCRIPTION
Two first commits are trivial UI improvements.

Third probably needs an explanation. I was almost hit by the situation where I increased the upper bounds of my dependencies, but there aren't valid install-plan which would contain actually newest versions of packages. Therefore I could be given an expression that my package works against new version of some dependency, but actually it doesn't.

For example, if I add `vector: >=0.9 && <0.11` direct dependency to `reflex-0.3`:

```
packdeps reflex.cabal
reflex-0.3: Can use newest versions of all dependencies
```

But if I run with `--recursive` flag, I get a lot of output with some interesting information:
```
packdeps --recursive reflex.cabal
reflex-0.3: Can use newest versions of all dependencies

Transitive dependencies:
reflex-0.3: Can use newest versions of all dependencies
base-4.8.1.0: Can use newest versions of all dependencies
ghc-prim-0.4.0.0: Can use newest versions of all dependencies
dependent-sum-0.2.1.0: Can use newest versions of all dependencies
dependent-map-0.1.1.3: Can use newest versions of all dependencies
containers-0.5.6.3: Can use newest versions of all dependencies
array-0.5.1.0: Can use newest versions of all dependencies
deepseq-1.4.1.1: Can use newest versions of all dependencies
semigroups-0.16.2.2: Can use newest versions of all dependencies
nats-1: Can use newest versions of all dependencies
mtl-2.2.1: Can use newest versions of all dependencies
transformers-0.4.3.0: Can use newest versions of all dependencies
these-0.4.2: Cannot accept the following packages
bifunctors 5
mtl 2.2.1
profunctors 5.1.1
semigroupoids 5.0.0.4
semigroups 0.16.2.2
transformers 0.4.3.0
vector 0.11.0.0
bifunctors-5: Can use newest versions of all dependencies
semigroupoids-5.0.0.4: Can use newest versions of all dependencies
base-orphans-0.4.4: Can use newest versions of all dependencies
transformers-compat-0.4.0.4: Can use newest versions of all dependencies
profunctors-5.1.1: Can use newest versions of all dependencies
comonad-4.2.7.2: Can use newest versions of all dependencies
tagged-0.8.1: Can use newest versions of all dependencies
distributive-0.4.4: Can use newest versions of all dependencies
vector-0.11.0.0: Can use newest versions of all dependencies
primitive-0.6: Can use newest versions of all dependencies
template-haskell-2.10.0.0: Can use newest versions of all dependencies
pretty-1.1.3.2: Can use newest versions of all dependencies
ref-tf-0.4: Can use newest versions of all dependencies
stm-2.4.4: Can use newest versions of all dependencies
exception-transformers-0.4.0.1: Can use newest versions of all dependencies
```