### PR TITLE
Improve compatibility with newer Cabal versions.

### DIFF
--- a/packdeps-cli/packdeps.cabal
+++ b/packdeps-cli/packdeps.cabal
@@ -18,6 +18,7 @@ extra-source-files: README.md ChangeLog.md
 
 library
     default-language: Haskell2010
+    extensions: CPP
     hs-source-dirs: src
     build-depends:   base                      >= 4.14     && < 5
                    , tar                       >= 0.4      && < 0.6

--- a/packdeps-cli/src/Distribution/PackDeps.hs
+++ b/packdeps-cli/src/Distribution/PackDeps.hs
@@ -252,7 +252,13 @@ getLibDeps gpd = maybe [] condTreeConstraints' (condLibrary gpd) ++ customDeps
 
     -- we only interested in Cabal default upper bound
     -- See cabal-install Distribution.Client.ProjectPlanning defaultSetupDeps
-    defSetupDeps = [Dependency (mkPackageName "Cabal") (earlierVersion $ mkVersion [1,25]) mempty]
+    defSetupDeps = [Dependency (mkPackageName "Cabal") (earlierVersion $ mkVersion [1,25])
+#if MIN_VERSION_Cabal(3, 4, 0)
+                               mainLibSet
+#else
+                               mempty
+#endif
+                   ]
 
 condTreeConstraints' :: Monoid c => CondTree ConfVar c a  -> c
 condTreeConstraints' = go where
@@ -265,7 +271,11 @@ condTreeConstraints' = go where
 notFlagCondition :: Condition ConfVar -> Bool
 notFlagCondition (Var (OS _))     = True
 notFlagCondition (Var (Arch _))   = True
+#if MIN_VERSION_Cabal(3, 4, 0)
+notFlagCondition (Var (PackageFlag _)) = False
+#else
 notFlagCondition (Var (Flag _))   = False
+#endif
 notFlagCondition (Var (Impl _ _)) = True
 notFlagCondition (Lit _)          = True
 notFlagCondition (CNot a)         = notFlagCondition a


### PR DESCRIPTION
packdeps-cli builds with "cabal build --allow-newer" now, even on very recent toolchains/libraries.

Note that packdeps-yesod still doesn't compile, because the constructors AnyVersion, VersionRangeParens, and WildcardVersion have been removed from Cabal 3.4.0.