### PR TITLE
Port to Cabal >= 3.4 and GHC >= 9.0

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,53 @@
+name: Stack build
+
+on:
+  push:
+    branches: [web]
+  pull_request:
+    branches: [web]
+
+jobs:
+  build:
+    name: Stack ${{ matrix.ghc }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.8', '9.6', '9.4', '9.2', '9.0']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: haskell-actions/setup@v2
+      id: setup
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        enable-stack: true
+        cabal-update: false
+
+    - name: Restore cache
+      uses: actions/cache/restore@v4
+      id: cache
+      env:
+        key: ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}
+      with:
+        path: |
+          ${{ steps.setup.outputs.stack-root }}
+          .stack-work
+        key: ${{ env.key }}-commit-${{ github.sha }}
+        restore-keys: ${{ env.key }}-
+
+    - name: Build dependencies
+      run:  stack build --stack-yaml=stack-${{ matrix.ghc }}.yaml --system-ghc --only-dependencies
+
+    - name: Build
+      run:  stack build --stack-yaml=stack-${{ matrix.ghc }}.yaml --system-ghc
+
+    - name: Save cache
+      uses: actions/cache/save@v4
+      if: always()
+      with:
+        key: ${{ steps.cache.outputs.cache-primary-key }}
+        path: |
+          ${{ steps.setup.outputs.stack-root }}
+          .stack-work

--- a/packdeps-cli/packdeps.cabal
+++ b/packdeps-cli/packdeps.cabal
@@ -18,6 +18,7 @@ extra-source-files: README.md ChangeLog.md
 
 library
     default-language: Haskell2010
+    extensions: CPP
     hs-source-dirs: src
     build-depends:   base                      >= 4.14     && < 5
                    , tar                       >= 0.4      && < 0.6

--- a/packdeps-cli/packdeps.cabal
+++ b/packdeps-cli/packdeps.cabal
@@ -18,14 +18,13 @@ extra-source-files: README.md ChangeLog.md
 
 library
     default-language: Haskell2010
-    extensions: CPP
     hs-source-dirs: src
     build-depends:   base                      >= 4.15     && < 5
                    , tar                       >= 0.4      && < 0.6
                    , split                     >= 0.1.2.3
                    , bytestring                >= 0.9
                    , text                      >= 0.7
-                   , Cabal                     >= 3.2      && < 3.3
+                   , Cabal                     >= 3.4
                    , time                      >= 1.1.4
                    , containers                >= 0.2
                    , directory                 >= 1.0

--- a/packdeps-cli/packdeps.cabal
+++ b/packdeps-cli/packdeps.cabal
@@ -41,7 +41,7 @@ executable             packdeps
 
     build-depends:   base
                    , Cabal
-                   , optparse-applicative      >=0.14 && <0.17
+                   , optparse-applicative      >=0.14
                    , containers
                    , semigroups
                    , process

--- a/packdeps-cli/packdeps.cabal
+++ b/packdeps-cli/packdeps.cabal
@@ -20,7 +20,7 @@ library
     default-language: Haskell2010
     extensions: CPP
     hs-source-dirs: src
-    build-depends:   base                      >= 4.14     && < 5
+    build-depends:   base                      >= 4.15     && < 5
                    , tar                       >= 0.4      && < 0.6
                    , split                     >= 0.1.2.3
                    , bytestring                >= 0.9
@@ -40,7 +40,7 @@ executable             packdeps
 
     ghc-options:       -Wall -rtsopts
 
-    build-depends:   base                      >= 4.14     && < 5
+    build-depends:   base
                    , Cabal
                    , optparse-applicative      >=0.14 && <0.17
                    , containers

--- a/packdeps-cli/src/Distribution/PackDeps.hs
+++ b/packdeps-cli/src/Distribution/PackDeps.hs
@@ -252,7 +252,13 @@ getLibDeps gpd = maybe [] condTreeConstraints' (condLibrary gpd) ++ customDeps
 
     -- we only interested in Cabal default upper bound
     -- See cabal-install Distribution.Client.ProjectPlanning defaultSetupDeps
-    defSetupDeps = [Dependency (mkPackageName "Cabal") (earlierVersion $ mkVersion [1,25]) mempty]
+    defSetupDeps = [Dependency (mkPackageName "Cabal") (earlierVersion $ mkVersion [1,25])
+#if MIN_VERSION_Cabal(3, 4, 0)
+                               mainLibSet
+#else
+                               mempty
+#endif
+                   ]
 
 condTreeConstraints' :: Monoid c => CondTree ConfVar c a  -> c
 condTreeConstraints' = go where
@@ -265,7 +271,11 @@ condTreeConstraints' = go where
 notFlagCondition :: Condition ConfVar -> Bool
 notFlagCondition (Var (OS _))     = True
 notFlagCondition (Var (Arch _))   = True
+#if MIN_VERSION_Cabal(3, 4, 0)
+notFlagCondition (Var (PackageFlag _)) = False
+#else
 notFlagCondition (Var (Flag _))   = False
+#endif
 notFlagCondition (Var (Impl _ _)) = True
 notFlagCondition (Lit _)          = True
 notFlagCondition (CNot a)         = notFlagCondition a

--- a/packdeps-cli/src/Distribution/PackDeps.hs
+++ b/packdeps-cli/src/Distribution/PackDeps.hs
@@ -46,7 +46,6 @@ import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec
 import Distribution.Parsec (Parsec, lexemeParsec, runParsecParser, simpleParsec)
 import Distribution.Parsec.FieldLineStream (fieldLineStreamFromBS)
-import Distribution.Types.CondTree
 import Distribution.Version
 import Distribution.Utils.ShortText
 import qualified Distribution.Utils.ShortText as ShortText
@@ -253,11 +252,7 @@ getLibDeps gpd = maybe [] condTreeConstraints' (condLibrary gpd) ++ customDeps
     -- we only interested in Cabal default upper bound
     -- See cabal-install Distribution.Client.ProjectPlanning defaultSetupDeps
     defSetupDeps = [Dependency (mkPackageName "Cabal") (earlierVersion $ mkVersion [1,25])
-#if MIN_VERSION_Cabal(3, 4, 0)
                                mainLibSet
-#else
-                               mempty
-#endif
                    ]
 
 condTreeConstraints' :: Monoid c => CondTree ConfVar c a  -> c
@@ -271,11 +266,7 @@ condTreeConstraints' = go where
 notFlagCondition :: Condition ConfVar -> Bool
 notFlagCondition (Var (OS _))     = True
 notFlagCondition (Var (Arch _))   = True
-#if MIN_VERSION_Cabal(3, 4, 0)
 notFlagCondition (Var (PackageFlag _)) = False
-#else
-notFlagCondition (Var (Flag _))   = False
-#endif
 notFlagCondition (Var (Impl _ _)) = True
 notFlagCondition (Lit _)          = True
 notFlagCondition (CNot a)         = notFlagCondition a

--- a/packdeps-cli/src/Distribution/PackDeps.hs
+++ b/packdeps-cli/src/Distribution/PackDeps.hs
@@ -4,7 +4,7 @@ module Distribution.PackDeps
     ( -- * Data types
       Newest
     , CheckDepsRes (..)
-    , DescInfo
+    , DescInfo (..)
       -- * Read package database
     , loadNewest
     , loadNewestFrom
@@ -28,7 +28,6 @@ module Distribution.PackDeps
       -- * Internal
     , PackInfo (..)
     , piRevision
-    , DescInfo (..)
     ) where
 
 import Control.Applicative as A ((<$>))

--- a/packdeps-yesod/packdeps-yesod.cabal
+++ b/packdeps-yesod/packdeps-yesod.cabal
@@ -1,3 +1,4 @@
+cabal-version:     >= 1.10
 name:              packdeps-yesod
 version:           0.0.0
 license:           BSD3
@@ -8,7 +9,6 @@ synopsis:          The greatest Yesod web application ever.
 description:       I'm sure you can say something clever here if you try.
 category:          Web
 stability:         Experimental
-cabal-version:     >= 1.8
 build-type:        Simple
 homepage:          http://packdeps.yesodweb.com/
 
@@ -40,7 +40,9 @@ library
     else
         ghc-options:   -Wall -threaded -O2
 
-    extensions: TemplateHaskell
+    default-language: Haskell2010
+    default-extensions:
+                TemplateHaskell
                 QuasiQuotes
                 OverloadedStrings
                 NoImplicitPrelude
@@ -101,4 +103,5 @@ executable         packdeps-server
     build-depends:     base
                      , packdeps-yesod
                      , yesod
-    ghc-options:   -Wall -threaded -O2
+    ghc-options:       -Wall -threaded -O2
+    default-language:  Haskell2010

--- a/packdeps-yesod/packdeps-yesod.cabal
+++ b/packdeps-yesod/packdeps-yesod.cabal
@@ -54,7 +54,7 @@ library
                 NoMonomorphismRestriction
                 ViewPatterns
 
-    build-depends: base                          >= 4          && < 5
+    build-depends: base                          >= 4.15         && < 5
                  , yesod                         >= 1.2
                  , yesod-core                    >= 1.2
                  , yesod-static                  >= 1.2
@@ -71,7 +71,7 @@ library
                  , directory                     >= 1.1
                  , warp                          >= 1.3
                  , http-conduit
-                 , http-client
+                 , http-client                   >= 0.5.0
                  , http-client-tls
                  , conduit                       >= 0.5
                  , time

--- a/packdeps-yesod/packdeps-yesod.cabal
+++ b/packdeps-yesod/packdeps-yesod.cabal
@@ -75,7 +75,7 @@ library
                  , http-client-tls
                  , conduit                       >= 0.5
                  , time
-                 , Cabal                         >= 3.2 && < 3.3
+                 , Cabal                         >= 3.4
                  , containers
                  , deepseq
                  , tar

--- a/packdeps-yesod/src/Application.hs
+++ b/packdeps-yesod/src/Application.hs
@@ -62,11 +62,7 @@ loadData update' = do
             hFlush stderr
     log "Entered loadData"
     req' <- parseUrlThrow "http://hackage.haskell.org/01-index.tar.gz"
-#if MIN_VERSION_http_client(0,5,0)
     let req = req' { responseTimeout = responseTimeoutMicro 30000000 }
-#else
-    let req = req' { responseTimeout = Just 30000000 }
-#endif
     forever $ do
         log "In forever"
         res <- try $ do

--- a/packdeps-yesod/src/Distribution/PackDeps.hs
+++ b/packdeps-yesod/src/Distribution/PackDeps.hs
@@ -50,12 +50,11 @@ import qualified Distribution.Utils.ShortText as ShortText
 
 import Distribution.Package hiding (PackageName)
 import qualified Distribution.Package as D
-import Distribution.PackageDescription
+import Distribution.PackageDescription hiding (PackageName)
 import Distribution.PackageDescription.Parsec
 import Distribution.Pretty (prettyShow)
-import Distribution.Types.CondTree (CondBranch (..))
 import qualified Distribution.Version as D
-import Distribution.Text hiding (Text)
+import Distribution.Text
 
 import qualified Data.Text as TS
 import qualified Data.ByteString.Lazy as L
@@ -247,7 +246,7 @@ getDeps gpd = HMap.map (fmap convertVersionRange)
 
     checkCond' _ (Var (OS _)) = True
     checkCond' _ (Var (Arch _)) = True
-    checkCond' flagMap (Var (Flag f)) = fromMaybe False $ Map.lookup f flagMap
+    checkCond' flagMap (Var (PackageFlag f)) = fromMaybe False $ Map.lookup f flagMap
     checkCond' _ (Var (Impl _compiler _range)) = True
     checkCond' _ (Lit b) = b
     checkCond' flagMap (CNot c) = not $ checkCond' flagMap c

--- a/packdeps-yesod/src/Distribution/PackDeps/Util.hs
+++ b/packdeps-yesod/src/Distribution/PackDeps/Util.hs
@@ -5,7 +5,6 @@ module Distribution.PackDeps.Util where
 import ClassyPrelude.Conduit
 import Distribution.PackDeps.Types
 import qualified Distribution.Version as D
-import qualified Distribution.Types.VersionRange.Internal as D
 import qualified Prelude
 
 withinRange :: Version -> VersionRange Version -> Bool
@@ -35,7 +34,6 @@ foldVersionRange anyv this later earlier union' intersect' = fold'
     fold' (WildcardVersion v)            = fold' (wildcard v)
     fold' (UnionVersionRanges v1 v2)     = union' (fold' v1) (fold' v2)
     fold' (IntersectVersionRanges v1 v2) = intersect' (fold' v1) (fold' v2)
-    fold' (VersionRangeParens v)         = fold' v
     fold' (MajorBoundVersion v)          = fold' (majorBound v)
     fold' (OrLaterVersion v)             = fold' (orLaterVersion v)
     fold' (OrEarlierVersion v)           = fold' (orEarlierVersion v)
@@ -68,20 +66,16 @@ orEarlierVersion :: Version -> VersionRange Version
 orEarlierVersion   v = UnionVersionRanges (ThisVersion v) (EarlierVersion v)
 
 convertVersionRange :: D.VersionRange -> VersionRange Version
-convertVersionRange =
-    goR
+convertVersionRange = D.cataVersionRange goR
   where
-    goR D.AnyVersion = AnyVersion
-    goR (D.ThisVersion x) = ThisVersion $ convertVersion x
-    goR (D.LaterVersion x) = LaterVersion $ convertVersion x
-    goR (D.EarlierVersion x) = EarlierVersion $ convertVersion x
-    goR (D.WildcardVersion x) = WildcardVersion $ convertVersion x
-    goR (D.UnionVersionRanges x y) = UnionVersionRanges (goR x) (goR y)
-    goR (D.IntersectVersionRanges x y) = IntersectVersionRanges (goR x) (goR y)
-    goR (D.VersionRangeParens x) = VersionRangeParens $ goR x
-    goR (D.MajorBoundVersion x) = MajorBoundVersion $ convertVersion x
-    goR (D.OrLaterVersion x) = OrLaterVersion $ convertVersion x
-    goR (D.OrEarlierVersion x) = OrEarlierVersion $ convertVersion x
+    goR (D.ThisVersionF x) = ThisVersion $ convertVersion x
+    goR (D.LaterVersionF x) = LaterVersion $ convertVersion x
+    goR (D.OrLaterVersionF x) = OrLaterVersion $ convertVersion x
+    goR (D.EarlierVersionF x) = EarlierVersion $ convertVersion x
+    goR (D.OrEarlierVersionF x) = OrEarlierVersion $ convertVersion x
+    goR (D.MajorBoundVersionF x) = MajorBoundVersion $ convertVersion x
+    goR (D.UnionVersionRangesF x y) = UnionVersionRanges x y
+    goR (D.IntersectVersionRangesF x y) = IntersectVersionRanges x y
 
 convertVersion :: D.Version -> Version
 convertVersion = Version

--- a/packdeps-yesod/src/Handler/License.hs
+++ b/packdeps-yesod/src/Handler/License.hs
@@ -4,7 +4,6 @@ import Import
 import Distribution.PackDeps.Types
 import Text.Lucius (luciusFile)
 import qualified Data.Map as Map
-import Data.Monoid ((<>))
 import Data.IORef (readIORef)
 import qualified Data.Set as Set
 

--- a/packdeps-yesod/src/Import.hs
+++ b/packdeps-yesod/src/Import.hs
@@ -7,9 +7,6 @@ module Import
     , module Data.Monoid
     , module Control.Applicative
     , Text
-#if __GLASGOW_HASKELL__ < 704
-    , (<>)
-#endif
     , isDeep
     , getDeps
     , getData
@@ -37,12 +34,6 @@ import Data.List (sortBy)
 import Distribution.PackDeps.Types (PackageName (PackageName), Version)
 import Distribution.Types.PackageName (unPackageName)
 import Data.IORef (readIORef)
-
-#if __GLASGOW_HASKELL__ < 704
-infixr 5 <>
-(<>) :: Monoid m => m -> m -> m
-(<>) = mappend
-#endif
 
 isDeep :: Handler Bool
 isDeep = fmap (== Just "on") $ runInputGet $ iopt textField "deep"

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -1,0 +1,4 @@
+resolver: lts-19.33
+packages:
+- packdeps-cli
+- packdeps-yesod

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -1,0 +1,4 @@
+resolver: lts-20.26
+packages:
+- packdeps-cli
+- packdeps-yesod

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -1,0 +1,4 @@
+resolver: lts-21.25
+packages:
+- packdeps-cli
+- packdeps-yesod

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,0 +1,4 @@
+resolver: lts-22.13
+packages:
+- packdeps-cli
+- packdeps-yesod

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,0 +1,4 @@
+resolver: nightly-2024-03-24
+packages:
+- packdeps-cli
+- packdeps-yesod

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-07-24
+resolver: lts-21.25
 packages:
 - packdeps-cli
 - packdeps-yesod

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 514590
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/7/24.yaml
-    sha256: 347514e3d62da1b886772e507aae245f8e84f8a4be469e0cffa26fc572542794
-  original: nightly-2020-07-24
+    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
+    size: 640086
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
+  original: lts-21.25


### PR DESCRIPTION
This PR continues 
- #60

We bump Cabal to >= 3.4 and GHC to >= 9.0.
A CI workflow is added to test build with the current GHC 9 major versions.

Most code changes are needed to adapt to new `Version` interface of Cabal-3.4.
 
Commits:
- **Improve compatibility with newer Cabal versions.** (#60)
- **Add workflow to build with GHC 9.0 - 9.8**
- **Drop build with GHC < 9 and http-client < 0.5**
- **packdeps-cli: drop building with Cabal < 3.4**
- **packdeps-yesod: Bump Cabal to >= 3.4**
- **packdeps-cli: bump cabal-version to >= 1.10**
- **packdeps-cli: remove duplicate export**
- **packdeps-cabal: allow newer optparse-applicative**
